### PR TITLE
feat: support for comma separated list of commits & deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ See [Examples](#examples) below for more details.
   with:
     # Optional. Can either be `post-deploy` or `post-status`. Defaults to `post-deploy`.
     action-type: string
-    # Required. Newline-separated list of deliverables the deployment contains (e.g., microservice name, application name). Defaults to repository name.
+    # Required. Newline-separated or comma-separated list of deliverables the deployment contains (e.g., microservice name, application name). Defaults to repository name.
     deliverables: string
-    # Required. Newline-separated list of commits SHA shipped as part of the deployment. Defaults to listing commits between the last 2 tags or as a last fallback $GITHUB_SHA.
+    # Required. Newline-separated or comma-separated list of commits SHA shipped as part of the deployment. Defaults to listing commits between the last 2 tags or as a last fallback $GITHUB_SHA.
     commits: string
     # Optional. Version being deployed.
     version: string

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,10 @@ author: "EchoesHQ"
 description: "Declare deployments and notify their status to Echoes."
 inputs:
   deliverables:
-    description: "Newline-separated list of deliverables the deployment contains (e.g., microservice name, application name)..."
+    description: "Newline-separated or comma-separated list of deliverables the deployment contains (e.g., microservice name, application name)..."
     required: false
   commits:
-    description: "Newline-separated list of commits SHA shipped as part of the deployment. Defaults to listing commits between the last 2 tags or as a last fallback $GITHUB_SHA."
+    description: "Newline-separated or comma-separated list of commits SHA shipped as part of the deployment. Defaults to listing commits between the last 2 tags or as a last fallback $GITHUB_SHA."
     required: false
   version:
     description: "Version being deployed."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,10 +14,32 @@ while getopts ":t:v:d:c:u:s:i:" opt; do
         v) version=$(trim "${OPTARG}")
         ;;
         d)
-        mapfile -t deliverables < <(trim "${OPTARG}")
+            deliverables=()
+
+            if [[ "${OPTARG}" =~ ^([^,]+,)+[^,]+$ ]]; then # Support comma separated list of deliverables
+                IFS=',' read -r -a raw_deliverables <<< "${OPTARG}"
+            else
+                mapfile -t raw_deliverables < <(echo "${OPTARG}") # Support Newline-separated list of deliverables
+            fi
+
+            for deliverable in "${raw_deliverables[@]}"; do
+                trimmed_deliverable=$(trim "$deliverable")
+                deliverables+=("$trimmed_deliverable")
+            done
         ;;
         c)
-        mapfile -t commits < <(trim "${OPTARG}")
+            commits=()
+
+            if [[ "${OPTARG}" =~ ^([^,]+,)+[^,]+$ ]]; then # Support comma separated list of commits
+                IFS=',' read -r -a raw_commits <<< "${OPTARG}"
+            else
+                mapfile -t raw_commits < <(echo "${OPTARG}")  # Support Newline-separated list of commits
+            fi
+
+            for commit in "${raw_commits[@]}"; do
+                trimmed_commit=$(trim "$commit")
+                commits+=("$trimmed_commit")
+            done
         ;;
         u) url=$(trim "${OPTARG}")
         ;;


### PR DESCRIPTION
The main motivation behind this change is to simplify the way commits or deliverables are passed to the Action.
It was previously accepting only a new line separated list of values while now it would also support a comma separated list of values.

Important to notice that GITHUB_ENV or GITHUB_OUTPUT do not support multi line values making the previous design tedious to work with.